### PR TITLE
feat(base-sepolia): add Base Sepolia reference deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ Deployed contract addresses and configs for the Haetae Finance ecosystem.
 ## Networks
 
 - [Giwa Testnet (Chain ID: 91342)](./giwa-testnet/)
+- [Base Sepolia (Chain ID: 84532)](./base-sepolia/) — reference deployment (publication pending)
 
 ## Quick Reference
 
-| Component | Status | Docs |
-|-----------|--------|------|
-| Beefy (Vault Infrastructure) | Deployed | [giwa-testnet/beefy.md](./giwa-testnet/beefy.md) |
-| Aerodrome (DEX) | Deployed | [giwa-testnet/aerodrome.md](./giwa-testnet/aerodrome.md) |
-| Test Tokens | Deployed | [giwa-testnet/tokens.md](./giwa-testnet/tokens.md) |
+| Component                    | Status   | Docs                                                     |
+| ---------------------------- | -------- | -------------------------------------------------------- |
+| Beefy (Vault Infrastructure) | Deployed | [giwa-testnet/beefy.md](./giwa-testnet/beefy.md)         |
+| Aerodrome (DEX)              | Deployed | [giwa-testnet/aerodrome.md](./giwa-testnet/aerodrome.md) |
+| Test Tokens                  | Deployed | [giwa-testnet/tokens.md](./giwa-testnet/tokens.md)       |

--- a/base-sepolia/aerodrome.md
+++ b/base-sepolia/aerodrome.md
@@ -1,0 +1,49 @@
+# Aerodrome DEX — Base Sepolia
+
+Deployed: 2026-04 (confirmed on-chain and from local deployment artifacts)
+Source: Fork of [aerodrome-finance/contracts](https://github.com/aerodrome-finance/contracts)
+
+## Core Contracts
+
+| Contract | Address |
+|----------|---------|
+| AERO (token) | `0xDe3e9B5bef343fb1991B378d64836e6fD48aD8f7` |
+| Router | `0x2DD7fBB5723B069a4B18e11581E1A053aECe8de5` |
+| PoolFactory | `0x8edAe844E1C6214FC36cfD252B751149d2969CE9` |
+| Voter | `0x98846C8323B26E788021Ff6017CB15fb787b2537` |
+| VotingEscrow | `0x67B27452642c9c45749a28213c260a6E25C14B23` |
+| Minter | `0x839623413a6906C7F554E0C330D62636F343C419` |
+| GaugeFactory | `0x86fDCE50DAD80144801D217bB074084eA7DF67B8` |
+| FactoryRegistry | `0x834657FB872fDAda9c77454D02329Be2135283C6` |
+| VotingRewardsFactory | `0xD5844cBe16A3f3ab16Ee4885f7161903CaaC6Ca4` |
+| ManagedRewardsFactory | `0xFfB6E811E68b55B0dD3bA2748230A6082EFeb29D` |
+| Forwarder | `0x73F4dEb0973158a89B7553D282fA33783eAD9883` |
+| ArtProxy | `0x72464736E898d8Ac2742f0C1C2b25c4ef7e3301c` |
+| Distributor | `0x54eC8566041194E7D6c541AD1565970077365BC7` |
+| AirdropDistributor | `0xfaB97D477A8D57d4ce4136dfd9f191E1836efCb4` |
+
+## Pools & Gauges
+
+| Pool | Type | Tokens | Pool Address | Gauge Address |
+|------|------|--------|-------------|---------------|
+| WETH/USDC | volatile | WETH + USDC | `0xD6ed234835501Fc468758C7e6AF8918d8758cF9D` | `0x6c83D4614433fF9BB437bBB9B19464E60955Bda5` |
+| DAI/USDC | stable | DAI + USDC | `0x201F470f314bb9f3eE701663b42be3aB976792cB` | `0x1c9297E7A99392402A33347aCc9e999fcFe9c786` |
+| AERO/WETH | volatile | AERO + WETH | `0x930Dd36139cCF43bbf6a08134e639039B6B10f30` | `0xf45a2651948075b241579aD2d0432BDb46F5f335` |
+| AERO/USDC | volatile | AERO + USDC | `0x2CF0970C8CCbf5718bD8035009D2A9A1BB39d79A` | `0x7C3AB768A4d8BC779b0D8320cC6c045Fa733c598` |
+
+## Notes
+
+- This Base Sepolia environment uses deployed test tokens for USDC/DAI rather than the public Circle Base Sepolia USDC.
+- Local deployment artifacts used for confirmation:
+  - `script/constants/output/DeployCore-BaseSepoliaHaetae.json`
+  - `script/constants/output/DeployGaugesAndPools-BaseSepoliaHaetae.json`
+  - `script/constants/output/DeployTestTokens-BaseSepoliaHaetae.json`
+
+## Beefy Integration
+
+| Beefy Parameter | Value |
+|-----------------|-------|
+| `solidlyRouter` | `0x2DD7fBB5723B069a4B18e11581E1A053aECe8de5` (Router) |
+| `_rewardPool` | Gauge address (per pool, see table above) |
+| `_rewards[0]` | `0xDe3e9B5bef343fb1991B378d64836e6fD48aD8f7` (AERO) |
+| `want` | Pool address = LP token (see table above) |

--- a/base-sepolia/beefy.md
+++ b/base-sepolia/beefy.md
@@ -1,0 +1,57 @@
+# Beefy (Vault Infrastructure) — Base Sepolia
+
+Deployed: 2026-04 (confirmed on-chain and from local deployment artifacts)
+
+## Infrastructure Contracts
+
+| Contract | Address |
+|----------|---------|
+| Vault owner (Timelock) | `0x5602729d1507cF0FBDAb479220A8166655331905` |
+| Vault Factory | `0x51E4561Dd264ee2DF47490acbf80BB2735A4bB37` |
+| BeefyFeeConfig (proxy) | `0xCB6C3B45A0557e36E3C432481dA29b32db930E19` |
+| BeefySwapper | `0xb0D539E96e99653a8E7A8D7bfB32c54A853cFC24` |
+| Deployer/Keeper (historical deployment account) | `0x5D2cd3e72fb4b08C80D729feE66dA4755E071147` |
+
+## Aerodrome vaults deployed
+
+### Vault — WETH/USDC (Aerodrome volatile)
+
+| Item | Value |
+|------|------|
+| Vault (proxy) | `0xF9bBf3EC1f0C90Fd7feDCd188A7Bfa73F9A6CD6a` |
+| Strategy | `0xd71A532E728b2307a8E54CBf313e1046918cb62D` |
+| Want (LP) | `0xD6ed234835501Fc468758C7e6AF8918d8758cF9D` |
+| Gauge | `0x6c83D4614433fF9BB437bBB9B19464E60955Bda5` |
+| Name | Moo Aerodrome Base Sepolia WETH-USDC |
+| Symbol | mooAerodromeBaseSepoliaWETH-USDC |
+| approvalDelay | 21600 (6h) |
+| lpToken0 / lpToken1 | USDC / WETH |
+| harvestOnDeposit | true |
+
+### Vault — DAI/USDC (Aerodrome stable)
+
+| Item | Value |
+|------|------|
+| Vault (proxy) | `0x9913adc053B53053e9Ad9E28E2d9e58237D9Fa87` |
+| Strategy | `0x19a032866501e7F94CC0ed85791F03772E64149C` |
+| Want (LP) | `0x201F470f314bb9f3eE701663b42be3aB976792cB` |
+| Gauge | `0x1c9297E7A99392402A33347aCc9e999fcFe9c786` |
+| Name | Moo Aerodrome Base Sepolia sDAI-USDC |
+| Symbol | mooAerodromeBaseSepoliasDAI-USDC |
+| approvalDelay | 21600 (6h) |
+| lpToken0 / lpToken1 | USDC / DAI |
+| harvestOnDeposit | true |
+
+## On-chain verification summary
+
+- `vault.strategy()` matches the listed strategy on both vaults
+- `strategy.want()` matches the corresponding LP pool on both strategies
+- `strategy.gauge()` matches the corresponding gauge on both strategies
+- `vault.owner()` matches the Base Sepolia timelock `0x5602729d1507cF0FBDAb479220A8166655331905`
+- `strategy.harvestOnDeposit()` is `true` on both strategies
+
+## Remaining follow-ups
+
+- Publish these addresses in FE/API downstream repos
+- Add `haetae-finance-api` Base Sepolia datasets/endpoints (`/vaults/base_sepolia`, `/tokens/base_sepolia`, `/apy`, `/tvl`, `/lps`)
+- If production/public usage is planned, clarify whether test-token USDC/DAI should be replaced with canonical Base Sepolia assets

--- a/base-sepolia/network.md
+++ b/base-sepolia/network.md
@@ -1,0 +1,23 @@
+# Base Sepolia
+
+| Item         | Value                                          |
+| ------------ | ---------------------------------------------- |
+| Chain ID     | `84532`                                        |
+| RPC          | `https://sepolia.base.org`                     |
+| Explorer     | `https://sepolia.basescan.org`                 |
+| Explorer API | `https://api-sepolia.basescan.org/api`         |
+| Faucet (web) | `https://www.alchemy.com/faucets/base-sepolia` |
+| Native Token | ETH                                            |
+| Stack        | OP Stack (Sepolia)                             |
+
+## Notes
+
+- This is a reference deployment. Base Sepolia data is not yet wired into `haetae-finance-api` (`/vaults/base_sepolia` currently returns `chainId not found`).
+- The Aerodrome fork and Beefy vault infrastructure were deployed separately from the production Base mainnet Aerodrome; see [aerodrome.md](./aerodrome.md) and [beefy.md](./beefy.md).
+- Deployed test tokens are used for USDC/DAI rather than canonical Base Sepolia assets — see [tokens.md](./tokens.md).
+
+## Deployer
+
+| Role                                            | Address                                      |
+| ----------------------------------------------- | -------------------------------------------- |
+| Deployer / Team / FeeManager / EmergencyCouncil | `0x5D2cd3e72fb4b08C80D729feE66dA4755E071147` |

--- a/base-sepolia/tokens.md
+++ b/base-sepolia/tokens.md
@@ -1,0 +1,22 @@
+# Test Tokens — Base Sepolia
+
+Deployed: 2026-04 (confirmed from local Aerodrome deployment outputs and on-chain bytecode)
+
+## Tokens used by the deployed Base Sepolia pools
+
+| Token | Address | Decimals | Notes |
+|-------|---------|----------|-------|
+| WETH | `0x4200000000000000000000000000000000000006` | 18 | Base Sepolia WETH predeploy |
+| USDC | `0x0F3Ae09e986f6E57812d662484043F5971151BD0` | 6 | Test token used in deployed Aerodrome pools |
+| DAI | `0x5c226913e80c3558d9a900dc88C08D231eD722D6` | 18 | Test token used in deployed Aerodrome pools |
+| AERO | `0xDe3e9B5bef343fb1991B378d64836e6fD48aD8f7` | 18 | Reward token |
+
+## Important note
+
+This Base Sepolia deployment does **not** use the public Circle Base Sepolia USDC token. Any downstream integration (frontend, API, docs, demo scripts) must use the addresses above until the environment is explicitly migrated.
+
+## Source artifacts
+
+- `script/constants/output/DeployCore-BaseSepoliaHaetae.json`
+- `script/constants/output/DeployTestTokens-BaseSepoliaHaetae.json`
+- `script/constants/output/DeployGaugesAndPools-BaseSepoliaHaetae.json`


### PR DESCRIPTION
## Summary

Adds `base-sepolia/` directory mirroring the existing `giwa-testnet/` structure.

## Changes

- `base-sepolia/aerodrome.md` — Aerodrome fork core contracts, 4 pools, 4 gauges
- `base-sepolia/beefy.md` — VaultFactory, FeeConfig, Swapper, Timelock, 2 vaults (WETH/USDC + DAI/USDC)
- `base-sepolia/network.md` — Chain ID 84532, RPC, explorer, faucet
- `base-sepolia/tokens.md` — WETH, USDC (test), DAI (test), AERO
- `README.md` — Networks 리스트에 Base Sepolia 1행 추가 (reference / publication pending)

## Sources

- On-chain verification against https://sepolia.base.org
- `haetae-finance/src/config/contracts.ts` (Base Sepolia block)
- `haetae-finance/src/config/vaults.ts` (BASE_SEPOLIA_VAULTS)
- `haetae-finance/docs/protocol/base-sepolia-deployments.md`

## Notes

- Base Sepolia 배포는 로컬 test 토큰으로 USDC/DAI를 사용 (Circle의 public Base Sepolia USDC 아님)
- Quick Reference 테이블은 기존 Giwa 전용 유지 (Base Sepolia는 참고용으로 Networks 섹션에만 링크)
- 후속: `haetae-finance-api`에 `/vaults/base_sepolia` 데이터셋 배포 필요 (4/30 데모 블로커)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Base Sepolia network configuration documentation including RPC endpoints and explorer URLs.
  * Documented Aerodrome DEX deployment on Base Sepolia with contract addresses and pool configurations.
  * Documented Beefy vault infrastructure deployment on Base Sepolia with vault and strategy details.
  * Added Base Sepolia test token configuration and on-chain addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->