### PR TITLE
docs(base-sepolia): add Multicall + AppMulticall + Oracle/Zap addresses

### DIFF
--- a/base-sepolia/beefy.md
+++ b/base-sepolia/beefy.md
@@ -4,43 +4,52 @@ Deployed: 2026-04 (confirmed on-chain and from local deployment artifacts)
 
 ## Infrastructure Contracts
 
-| Contract | Address |
-|----------|---------|
-| Vault owner (Timelock) | `0x5602729d1507cF0FBDAb479220A8166655331905` |
-| Vault Factory | `0x51E4561Dd264ee2DF47490acbf80BB2735A4bB37` |
-| BeefyFeeConfig (proxy) | `0xCB6C3B45A0557e36E3C432481dA29b32db930E19` |
-| BeefySwapper | `0xb0D539E96e99653a8E7A8D7bfB32c54A853cFC24` |
+| Contract                                        | Address                                      |
+| ----------------------------------------------- | -------------------------------------------- |
+| Vault owner (Timelock)                          | `0x5602729d1507cF0FBDAb479220A8166655331905` |
+| Vault Factory                                   | `0x51E4561Dd264ee2DF47490acbf80BB2735A4bB37` |
+| Multicall (Beefy)                               | `0xb3F76b75623A859eeC180E33b0f886B19C72bA51` |
+| BeefyV2AppMulticall                             | `0xb174A2816929ab5B7a126A7Ea424B65Df438b24B` |
+| BeefyFeeConfig (proxy)                          | `0xCB6C3B45A0557e36E3C432481dA29b32db930E19` |
+| BeefyOracle                                     | `0xf9364d8d5D0ee34a1c1Acf2c40B9bc212aF3D70F` |
+| FixedOracle                                     | `0x970317143394a34Bc7ff1d80a44a32eA5E89a1EA` |
+| BeefySwapper                                    | `0xb0D539E96e99653a8E7A8D7bfB32c54A853cFC24` |
+| Zap                                             | `0xc0fA3412Fd58F5C0CD20588438438bB4f981644b` |
 | Deployer/Keeper (historical deployment account) | `0x5D2cd3e72fb4b08C80D729feE66dA4755E071147` |
+
+> **Multicall (Beefy)** — `contracts/BIFI/utils/Multicall.sol` (generic aggregate). Beefy address-book(`beefyfinance.ts`)의 `multicall` 필드 대상. 2026-04-23 배포(tx `0x4ab9d67a4bb8a090cac8f0e4b79e7c032f5335e0e58ffeb43f814899d9a72a91`).
+>
+> **BeefyV2AppMulticall** — `contracts/BIFI/infra/BeefyV2AppMulticall.sol`. Beefy API `fetchAmmPrices.ts`의 `MULTICALLS` 맵 대상(volatile LP 가격 산출). 2026-04-23 배포.
 
 ## Aerodrome vaults deployed
 
 ### Vault — WETH/USDC (Aerodrome volatile)
 
-| Item | Value |
-|------|------|
-| Vault (proxy) | `0xF9bBf3EC1f0C90Fd7feDCd188A7Bfa73F9A6CD6a` |
-| Strategy | `0xd71A532E728b2307a8E54CBf313e1046918cb62D` |
-| Want (LP) | `0xD6ed234835501Fc468758C7e6AF8918d8758cF9D` |
-| Gauge | `0x6c83D4614433fF9BB437bBB9B19464E60955Bda5` |
-| Name | Moo Aerodrome Base Sepolia WETH-USDC |
-| Symbol | mooAerodromeBaseSepoliaWETH-USDC |
-| approvalDelay | 21600 (6h) |
-| lpToken0 / lpToken1 | USDC / WETH |
-| harvestOnDeposit | true |
+| Item                | Value                                        |
+| ------------------- | -------------------------------------------- |
+| Vault (proxy)       | `0xF9bBf3EC1f0C90Fd7feDCd188A7Bfa73F9A6CD6a` |
+| Strategy            | `0xd71A532E728b2307a8E54CBf313e1046918cb62D` |
+| Want (LP)           | `0xD6ed234835501Fc468758C7e6AF8918d8758cF9D` |
+| Gauge               | `0x6c83D4614433fF9BB437bBB9B19464E60955Bda5` |
+| Name                | Moo Aerodrome Base Sepolia WETH-USDC         |
+| Symbol              | mooAerodromeBaseSepoliaWETH-USDC             |
+| approvalDelay       | 21600 (6h)                                   |
+| lpToken0 / lpToken1 | USDC / WETH                                  |
+| harvestOnDeposit    | true                                         |
 
 ### Vault — DAI/USDC (Aerodrome stable)
 
-| Item | Value |
-|------|------|
-| Vault (proxy) | `0x9913adc053B53053e9Ad9E28E2d9e58237D9Fa87` |
-| Strategy | `0x19a032866501e7F94CC0ed85791F03772E64149C` |
-| Want (LP) | `0x201F470f314bb9f3eE701663b42be3aB976792cB` |
-| Gauge | `0x1c9297E7A99392402A33347aCc9e999fcFe9c786` |
-| Name | Moo Aerodrome Base Sepolia sDAI-USDC |
-| Symbol | mooAerodromeBaseSepoliasDAI-USDC |
-| approvalDelay | 21600 (6h) |
-| lpToken0 / lpToken1 | USDC / DAI |
-| harvestOnDeposit | true |
+| Item                | Value                                        |
+| ------------------- | -------------------------------------------- |
+| Vault (proxy)       | `0x9913adc053B53053e9Ad9E28E2d9e58237D9Fa87` |
+| Strategy            | `0x19a032866501e7F94CC0ed85791F03772E64149C` |
+| Want (LP)           | `0x201F470f314bb9f3eE701663b42be3aB976792cB` |
+| Gauge               | `0x1c9297E7A99392402A33347aCc9e999fcFe9c786` |
+| Name                | Moo Aerodrome Base Sepolia sDAI-USDC         |
+| Symbol              | mooAerodromeBaseSepoliasDAI-USDC             |
+| approvalDelay       | 21600 (6h)                                   |
+| lpToken0 / lpToken1 | USDC / DAI                                   |
+| harvestOnDeposit    | true                                         |
 
 ## On-chain verification summary
 


### PR DESCRIPTION
## Summary

Base Sepolia `Infrastructure Contracts` 섹션에 5개 주소를 추가해 `deployments` 리포를 single source of truth로 정리한다. 두 Multicall 컨트랙트는 이 PR과 함께 신규 배포, 나머지 3개(BeefyOracle / FixedOracle / Zap)는 기존 배포분을 `haetae-finance-api#26`에서 이관.

## Newly deployed (2026-04-23)

| Contract | Address | Tx |
|---|---|---|
| Multicall (generic) | `0xb3F76b75623A859eeC180E33b0f886B19C72bA51` | [`0x4ab9d6…a72a91`](https://sepolia.basescan.org/tx/0x4ab9d67a4bb8a090cac8f0e4b79e7c032f5335e0e58ffeb43f814899d9a72a91) |
| BeefyV2AppMulticall | `0xb174A2816929ab5B7a126A7Ea424B65Df438b24B` | (Basescan 조회) |

- On-chain bytecode 검증 ✅ (Multicall 3126 chars, AppMulticall 17120 chars)
- Multicall bytecode hash = Giwa Multicall과 동일 → same `contracts/BIFI/utils/Multicall.sol`

## Migrated from haetae-finance-api#26

- BeefyOracle — `0xf9364d8d5D0ee34a1c1Acf2c40B9bc212aF3D70F` (bytecode 7608 chars)
- FixedOracle — `0x970317143394a34Bc7ff1d80a44a32eA5E89a1EA` (bytecode 686 chars)
- Zap — `0xc0fA3412Fd58F5C0CD20588438438bB4f981644b` (bytecode 24398 chars)

## Diff noise note

Markdown 테이블 포맷이 aligned columns로 일괄 재정렬되어 있음(자동 포매터). 실제 내용 변경은 **Infrastructure Contracts 5개 행 + 컨트랙트 역할 주석**뿐. Aerodrome vault 섹션은 내용 변경 없이 포맷만 변경.

## Downstream impact

- `haetae-finance-api` **BE-28** 언블록 (WETH/USDC volatile LP price 산출)
- `haetae-finance-api` **BE-29** 트리거 — `src/utils/fetchAmmPrices.ts` `MULTICALLS` 맵에 `84532: '0xb174A2816929ab5B7a126A7Ea424B65Df438b24B'` 등록
- `beefy-api` address-book `beefyfinance.ts`의 `base_sepolia`에 `multicall: '0xb3F76b75623A859eeC180E33b0f886B19C72bA51'` 등록

## Clarifications

- **Multicall (Beefy)** vs **BeefyV2AppMulticall** — 서로 다른 컨트랙트. 전자는 address-book용(`contracts/BIFI/utils/Multicall.sol`), 후자는 API `fetchAmmPrices`용(`contracts/BIFI/infra/BeefyV2AppMulticall.sol`).
- 이슈 #17에서 언급된 주소 충돌(`0xDe3e9B5bef343fb1991B378d64836e6fD48aD8f7`) 검증 결과: Base Sepolia에서 이 주소는 **AERO 토큰(ERC20)**, Giwa에서는 **Multicall**. 동일 deployer의 nonce 공유로 인한 주소 겹침이며 실제 컨트랙트는 서로 다름. 따라서 Base Sepolia용 Multicall은 새 주소에 신규 배포가 맞다.

Closes #16
Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 인프라스트럭처 계약 문서가 추가 계약 주소 정보 및 배포 세부사항과 함께 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->