### PR TITLE
docs(base-sepolia): add BeefyPriceMulticall + clarify AppMulticall role

### DIFF
--- a/base-sepolia/beefy.md
+++ b/base-sepolia/beefy.md
@@ -10,6 +10,7 @@ Deployed: 2026-04 (confirmed on-chain and from local deployment artifacts)
 | Vault Factory                                   | `0x51E4561Dd264ee2DF47490acbf80BB2735A4bB37` |
 | Multicall (Beefy)                               | `0xb3F76b75623A859eeC180E33b0f886B19C72bA51` |
 | BeefyV2AppMulticall                             | `0xb174A2816929ab5B7a126A7Ea424B65Df438b24B` |
+| BeefyPriceMulticall                             | `0xAF9a48f499b85d9aa2509AFb9aF50A0b26D06e48` |
 | BeefyFeeConfig (proxy)                          | `0xCB6C3B45A0557e36E3C432481dA29b32db930E19` |
 | BeefyOracle                                     | `0xf9364d8d5D0ee34a1c1Acf2c40B9bc212aF3D70F` |
 | FixedOracle                                     | `0x970317143394a34Bc7ff1d80a44a32eA5E89a1EA` |
@@ -17,9 +18,13 @@ Deployed: 2026-04 (confirmed on-chain and from local deployment artifacts)
 | Zap                                             | `0xc0fA3412Fd58F5C0CD20588438438bB4f981644b` |
 | Deployer/Keeper (historical deployment account) | `0x5D2cd3e72fb4b08C80D729feE66dA4755E071147` |
 
-> **Multicall (Beefy)** — `contracts/BIFI/utils/Multicall.sol` (generic aggregate). Beefy address-book(`beefyfinance.ts`)의 `multicall` 필드 대상. 2026-04-23 배포(tx `0x4ab9d67a4bb8a090cac8f0e4b79e7c032f5335e0e58ffeb43f814899d9a72a91`).
+> **Multicall (Beefy)** — `contracts/BIFI/utils/Multicall.sol` (generic aggregate). Beefy address-book(`beefyfinance.ts`)의 `multicall` 필드 대상. 2026-04-23 배포(tx `0x4ab9d67a4bb8a090cac8f0e4b79e7c032f5335e0e58ffeb43f814899d9a72a91`). Bytecode ~1.6KB.
 >
-> **BeefyV2AppMulticall** — `contracts/BIFI/infra/BeefyV2AppMulticall.sol`. Beefy API `fetchAmmPrices.ts`의 `MULTICALLS` 맵 대상(volatile LP 가격 산출). 2026-04-23 배포.
+> **BeefyV2AppMulticall** — `contracts/BIFI/infra/BeefyV2AppMulticall.sol`. Beefy **App frontend**가 vault 정보(TVL/APY/balance)를 일괄 조회하기 위한 멀티콜 헬퍼. 2026-04-23 배포. Bytecode ~8.6KB.
+>
+> **BeefyPriceMulticall** — `contracts/BIFI/infra/BeefyPriceMulticall.sol`. Beefy **API** `fetchAmmPrices.ts`의 `MULTICALLS` 맵 대상(`getLpInfo(address[][])`로 volatile LP의 `totalSupply`·`token0/token1 balanceOf` 일괄 조회 → LP 단가 산출). 2026-04-23 배포(tx `0x91c62cc99e45f1e29236202eb3822f1acf190c2205417e241a8a91bed9935e50`). Bytecode ~1.4KB. Giwa 선례: `0x1a7f8ee57F9CfB1C1f7940e736e352E01DbA6a29`.
+>
+> ⚠️ `BeefyV2AppMulticall`과 `BeefyPriceMulticall`은 이름이 비슷하지만 **서로 다른 컨트랙트**다. API가 요구하는 것은 `getLpInfo` selector를 갖는 `BeefyPriceMulticall`이며, AppMulticall은 해당 selector가 없어 API에서 사용할 수 없다.
 
 ## Aerodrome vaults deployed
 


### PR DESCRIPTION
## Summary

Base Sepolia Infrastructure Contracts에 **`BeefyPriceMulticall`** 행 추가 + 기존 `BeefyV2AppMulticall` inline 주석 오류 수정.

## Newly deployed (2026-04-23)

| Contract | Address | Tx | Bytecode |
|---|---|---|---|
| BeefyPriceMulticall | `0xAF9a48f499b85d9aa2509AFb9aF50A0b26D06e48` | [`0x91c62c…9935e50`](https://sepolia.basescan.org/tx/0x91c62cc99e45f1e29236202eb3822f1acf190c2205417e241a8a91bed9935e50) | **1,383 B** |

### On-chain 검증 (3-lens)

1. **Bytecode size**: `cast code` 결과 1,383B — Giwa 선례 `0x1a7f8ee5…`의 1,328B와 55B diff (컴파일러/옵티마이저 세팅 차이, 기능 동일).
2. **`getLpInfo([])` 호출**: `cast call 0xAF9a… "getLpInfo(address[][])" "[]"` → ABI-encoded empty array 정상 반환 (**not reverted**). 이전 BC팀 배포 `0xb174…B24B`는 동일 호출에서 revert.
3. **From**: `0x5D2c…1147` (deployments#18와 동일 deployer).

## Correction of pre-existing note

기존 inline note (이름 혼동의 뿌리):

\`\`\`md
> **BeefyV2AppMulticall** — … Beefy API \`fetchAmmPrices.ts\`의 \`MULTICALLS\` 맵 대상(volatile LP 가격 산출). …
\`\`\`

**실제**: \`fetchAmmPrices.ts\`의 \`MULTICALLS\` 맵이 요구하는 것은 \`BeefyPriceMulticall\` (\`getLpInfo\` selector 보유)이며, \`BeefyV2AppMulticall\`은 \`getLpInfo\`를 갖지 않는다. 이 PR에서 두 컨트랙트의 역할을 정확히 분리 기술:

- \`BeefyV2AppMulticall\` (8.6KB) — Beefy **App frontend**용 (vault TVL/APY/balance 일괄 조회)
- \`BeefyPriceMulticall\` (1.4KB) — Beefy **API**용 (\`fetchAmmPrices\` volatile LP 가격 산출)

이 표기 오류가 deployments#17 요청 해석 시 혼동을 일으켜, BC팀이 \`deployAppMulticall.js\` 를 실행하고 \`BeefyV2AppMulticall\` 을 배포하는 결과로 이어졌다(이슈 #20 배경). 같은 혼동 재발 방지 목적으로 주석에 ⚠️ 경고 추가.

## Downstream

- **BE (다음)** — \`haetae-finance-api/src/utils/fetchAmmPrices.ts\` \`MULTICALLS\` Map에 \`[84532, '0xAF9a48f499b85d9aa2509AFb9aF50A0b26D06e48']\` 추가 (BE-29). Dev ECS 배포 후 \`/lps\` 84532 volatile LP, \`/tvl\` 84532 \`aerodrome-base-sepolia-weth-usdc\` 정상화 확인.
- **CT** — \`haetae-finance-contracts\`에 신규 배포 스크립트 PR: [haetae-dev/haetae-finance-contracts#1](https://github.com/haetae-dev/haetae-finance-contracts/pull/1) (\`deployPriceMulticall.js\` + baseSepolia etherscan customChain).
- **Verify** — 현재 \`BASE_API_KEY\` 미설정으로 Basescan verify skip. API 키 제공 시 \`npx hardhat verify --network baseSepolia 0xAF9a… \`로 수동 진행 가능(API 동작과 무관).

## Related

- Root cause: [deployments#17](https://github.com/haetae-dev/deployments/issues/17) (이름 혼동 유발 표기) / deployments#18 (잘못된 배포)
- Issue: Closes #20
- Contract source: \`contracts/BIFI/infra/BeefyPriceMulticall.sol\` (haetae-finance-contracts)
- Giwa precedent: \`0x1a7f8ee57F9CfB1C1f7940e736e352E01DbA6a29\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 인프라 계약 목록에 새로운 계약 주소를 추가했습니다.
  * 기존 계약 항목에 바이트코드 크기 정보를 추가했습니다.
  * 두 개의 서로 다른 계약 간의 구분에 대한 명확한 설명을 제공했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->